### PR TITLE
fix: style

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   </head>
 
   <body>


### PR DESCRIPTION
webpackerの設定でextractCssがtrueになってる場合は、cssがprecompile後に別ファイルになります。
なので、*.vueなどに<style>タグを書いた時はstylesheet_pack_tagの追加も必要です
という話ですね


## before
<img width="1432" alt="スクリーンショット 2020-06-17 10 43 20" src="https://user-images.githubusercontent.com/11803765/84845348-659bbc00-b087-11ea-9cb8-e63764322245.png">

## after
<img width="1431" alt="スクリーンショット 2020-06-17 10 42 51" src="https://user-images.githubusercontent.com/11803765/84845353-67657f80-b087-11ea-9931-b5e32eaac240.png">
